### PR TITLE
Succession Time Step Bug Fix

### DIFF
--- a/DatasetParser.cs
+++ b/DatasetParser.cs
@@ -170,7 +170,16 @@ namespace Landis.Library.InitialCommunities
             foreach(ushort age in ageBios.Keys)
             {
                 if (age % successionTimestep == 0)
-                    newList.Add(age, ageBios[age]);
+                {
+                    if (newList.ContainsKey(age))
+                    {
+                        newList[age] += ageBios[age];
+                    }
+                    else
+                    {
+                        newList.Add(age, ageBios[age]);
+                    }
+                }
                 else
                 {
                     ushort new_age = (ushort)(((age / successionTimestep) + 1) * successionTimestep);


### PR DESCRIPTION
Fixed an issue where with certain parameter values the program would attempt to add multiple keys of the same value in a dictionary. This caused the program to crash and fail. Code now checks to see if the key already exists and if so to bin the value within that key.